### PR TITLE
[service.subtitles.opensubtitles] 5.1.2

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.subtitles.opensubtitles"
        name="OpenSubtitles.org"
-       version="5.1.1"
+       version="5.1.2"
        provider-name="amet, opensubtitles, juokelis">
 	<requires>
 		<import addon="xbmc.python" version="3.0.0"/>
@@ -51,27 +51,21 @@
 		<description lang="zh_CN">多语种的电影及剧集字幕，每日更新千余条翻译好的字幕。免费下载，提供API接口，已拥有上百万的用户。</description>
 		<disclaimer lang="en_GB">Users need to provide OpenSubtitles.org username and password in add-on configuration</disclaimer>                                               
 		<news>
-v5.1.1 (2020-03-21) by juokelis
-- Fixed issue with language flag icons
-
-v5.1.0 (2020-03-11) by juokelis
-- Ported to python 3.0. The 30th anniversary of the Restoration of Independence of Lithuania
-
-v5.0.16 (2016-11-26) by opensubtitles
-- Changed descriptions, icons, fanart... (by opensubtitles)
+v5.1.2 (2020-03-21) by enen92
+- Fixes for python3/matrix. Remove sys.path.append.
 		</news>
 		<platform>all</platform>
-		<license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
+		<license>GPL-2.0-only</license>
 		<forum>https://forum.opensubtitles.org/viewtopic.php?f=8&amp;t=15847</forum>
 		<website>http://www.opensubtitles.org</website>
-		<email>admin [at] opensubtitles {dot} org</email>                                               
+		<email>admin [at] opensubtitles {dot} org</email>
 		<assets>
 			<icon>resources/media/os_logo_512x512.png</icon>
-			<fanart>resources/media/os_fanart.jpg</fanart>    
+			<fanart>resources/media/os_fanart.jpg</fanart>
 			<screenshot>resources/media/screenshot_1.jpg</screenshot>
 			<screenshot>resources/media/screenshot_2.jpg</screenshot>
-			<screenshot>resources/media/screenshot_3.jpg</screenshot>				
+			<screenshot>resources/media/screenshot_3.jpg</screenshot>
 		</assets>
-		<source>https://github.com/juokelis/service.subtitles.opensubtitles</source>    
+		<source>https://github.com/juokelis/service.subtitles.opensubtitles</source>
 	</extension>
 </addon>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+5.1.2
+- Fixes for python3/matrix. Remove sys.path.append.
+
 5.1.1
 - Fixed issue with language flag icons
 

--- a/resources/lib/OSUtilities.py
+++ b/resources/lib/OSUtilities.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*- 
+# -*- coding: utf-8 -*-
 
 import os
 import sys
@@ -22,10 +22,11 @@ class OSDBServer:
   def __init__( self, *args, **kwargs ):
     self.server = xmlrpc.client.ServerProxy( BASE_URL_XMLRPC, verbose=0 )
     login = self.server.LogIn(__addon__.getSetting( "OSuser" ), __addon__.getSetting( "OSpass" ), "en", "%s_v%s" %(__scriptname__.replace(" ","_"),__version__))
-    if (login["status"] == "200 OK"):
-      self.osdb_token  = login[ "token" ]
+    if login["status"] == "200 OK":
+      self.osdb_token  = login["token"]
+
   def searchsubtitles( self, item):
-    if ( self.osdb_token ) :
+    if self.osdb_token:
       searchlist  = []
       if item['mansearch']:
         searchlist = [{'sublanguageid':",".join(item['3let_language']),
@@ -41,13 +42,13 @@ class OSDBServer:
         OS_search_string = ("%s S%.2dE%.2d" % (item['tvshow'],
                                                 int(item['season']),
                                                 int(item['episode']),)
-                                              ).replace(" ","+")      
+                                              ).replace(" ","+")
       else:
         if str(item['year']) == "":
           item['title'], item['year'] = xbmc.getCleanMovieTitle( item['title'] )
-    
+
         OS_search_string = item['title'].replace(" ","+")
-    
+
       log( __name__ , "Search String [ %s ]" % (OS_search_string,))
 
       if not item['temp']:
@@ -60,9 +61,9 @@ class OSDBServer:
                             })
         except:
           pass
-            
+
         imdb = str(xbmc.Player().getVideoInfoTag().getIMDBNumber().replace('tt',''))
-        
+
         if ((not item['tvshow']) and imdb != ""):
           searchlist.append({'sublanguageid' :",".join(item['3let_language']),
                              'imdbid'        :imdb
@@ -70,8 +71,8 @@ class OSDBServer:
 
         searchlist.append({'sublanguageid':",".join(item['3let_language']),
                           'query'        :OS_search_string
-                         }) 
-      
+                         })
+
       else:
         searchlist = [{'sublanguageid':",".join(item['3let_language']),
                        'query'        :OS_search_string
@@ -80,7 +81,7 @@ class OSDBServer:
       search = self.server.SearchSubtitles( self.osdb_token, searchlist )
 
       if search["data"]:
-        return search["data"] 
+        return search["data"]
 
 
   def download(self, ID, dest):
@@ -101,23 +102,23 @@ class OSDBServer:
        return False
 
 def log(module, msg):
-  xbmc.log((u"### [%s] - %s" % (module,msg,)),level=xbmc.LOGDEBUG ) 
+  xbmc.log((u"### [%s] - %s" % (module,msg,)),level=xbmc.LOGDEBUG )
 
 def hashFile(file_path, rar):
     if rar:
       return OpensubtitlesHashRar(file_path)
-      
-    log( __name__,"Hash Standard file")  
+
+    log( __name__,"Hash Standard file")
     longlongformat = 'q'  # long long
     bytesize = struct.calcsize(longlongformat)
     f = xbmcvfs.File(file_path)
-    
+
     filesize = f.size()
     hash = filesize
-    
+
     if filesize < 65536 * 2:
         return "SizeError"
-    
+
     buffer = f.read(65536)
     f.seek(max(0,filesize-65536),0)
     buffer += f.read(65536)
@@ -127,7 +128,7 @@ def hashFile(file_path, rar):
         (l_value,)= struct.unpack(longlongformat, buffer[size:size+bytesize])
         hash += l_value
         hash = hash & 0xFFFFFFFFFFFFFFFF
-    
+
     returnHash = "%016x" % hash
     return filesize,returnHash
 
@@ -141,11 +142,11 @@ def OpensubtitlesHashRar(firsrarfile):
     seek=0
     for i in range(4):
         f.seek(max(0,seek),0)
-        a=f.read(100)        
-        type,flag,size=struct.unpack( '<BHH', a[2:2+5]) 
+        a=f.read(100)
+        type,flag,size=struct.unpack( '<BHH', a[2:2+5])
         if 0x74==type:
             if 0x30!=struct.unpack( '<B', a[25:25+1])[0]:
-                raise Exception('Bad compression method! Work only for "store".')            
+                raise Exception('Bad compression method! Work only for "store".')
             s_partiizebodystart=seek+size
             s_partiizebody,s_unpacksize=struct.unpack( '<II', a[7:7+2*4])
             if (flag & 0x0100):
@@ -174,7 +175,7 @@ def addfilehash(name,hash,seek):
     for i in range(8192):
         hash+=struct.unpack('<q', f.read(8))[0]
         hash =hash & 0xffffffffffffffff
-    f.close()    
+    f.close()
     return hash
 
 def normalizeString(str):

--- a/resources/lib/__init__.py
+++ b/resources/lib/__init__.py
@@ -1,1 +1,0 @@
-# Dummy file to make this directory a package.

--- a/service.py
+++ b/service.py
@@ -17,19 +17,17 @@ __scriptname__ = __addon__.getAddonInfo('name')
 __version__    = __addon__.getAddonInfo('version')
 __language__   = __addon__.getLocalizedString
 
-__cwd__        = xbmc.translatePath( __addon__.getAddonInfo('path') )
-__profile__    = xbmc.translatePath( __addon__.getAddonInfo('profile') )
-__resource__   = xbmc.translatePath( os.path.join( __cwd__, 'resources', 'lib' ) )
-__temp__       = xbmc.translatePath( os.path.join( __profile__, 'temp', '') )
+__cwd__        = xbmcvfs.translatePath( __addon__.getAddonInfo('path') )
+__profile__    = xbmcvfs.translatePath( __addon__.getAddonInfo('profile') )
+__temp__       = xbmcvfs.translatePath( os.path.join( __profile__, 'temp', '') )
 
 if xbmcvfs.exists(__temp__):
   shutil.rmtree(__temp__)
 xbmcvfs.mkdirs(__temp__)
 
-sys.path.append (__resource__)
-
-from OSUtilities import OSDBServer, log, hashFile, normalizeString
 from urllib.parse import unquote
+from resources.lib.OSUtilities import OSDBServer, log, hashFile, normalizeString
+
 
 def Search( item ):
   search_data = []
@@ -37,8 +35,7 @@ def Search( item ):
     search_data = OSDBServer().searchsubtitles(item)
   except:
     log( __name__, "failed to connect to service for subtitle search")
-    xbmcgui.Dialog().ok(__scriptname__, __language__(32001),__language__(32005))
-    # xbmc.executebuiltin((u'Notification(%s,%s,%s,%s/icon.png)' % (__scriptname__ , __language__(32001),"5000",__cwd__)).encode('utf-8'))
+    xbmcgui.Dialog().ok(__scriptname__, '{}\n{}'.format(__language__(32001),__language__(32005)))
     return
 
   if search_data != None:
@@ -87,12 +84,12 @@ def Download(id,url,format,stack=False):
   if not result:
     log( __name__,"Download Using HTTP")
     zip = os.path.join( __temp__, "OpenSubtitles.zip")
-    f = urllib.urlopen(url)
+    f = urllib.request.urlopen(url)
     with open(zip, "wb") as subFile:
       subFile.write(f.read())
-    subFile.close()
+
     xbmc.sleep(500)
-    xbmc.executebuiltin(('XBMC.Extract("%s","%s")' % (zip,__temp__,)).encode('utf-8'), True)
+    xbmc.executebuiltin(('Extract("%s","%s")' % (zip,__temp__,)).encode('utf-8'), True)
     for file in xbmcvfs.listdir(zip)[1]:
       file = os.path.join(__temp__, file)
       if (os.path.splitext( file )[1] in exts):


### PR DESCRIPTION
Hey @juokelis,

Noticed a few bugs when using this addon in matrix. Since it is one of our main addons, it'd be great if you can update it:

- Dialog.ok arguments changed in matrix
- Builtins no longer use the XBMC.prefix
- Using sys.path.append is a bad practice
- Trailing whitespace cleanup
- A few python2 leftovers

I can submit the update to the repo on your behalf if you approve and merge this