### PR TITLE
Fix translatePath() calls

### DIFF
--- a/service.py
+++ b/service.py
@@ -17,9 +17,9 @@ __scriptname__ = __addon__.getAddonInfo('name')
 __version__    = __addon__.getAddonInfo('version')
 __language__   = __addon__.getLocalizedString
 
-__cwd__        = xbmcvfs.translatePath( __addon__.getAddonInfo('path') )
-__profile__    = xbmcvfs.translatePath( __addon__.getAddonInfo('profile') )
-__temp__       = xbmcvfs.translatePath( os.path.join( __profile__, 'temp', '') )
+__cwd__        = xbmc.translatePath( __addon__.getAddonInfo('path') )
+__profile__    = xbmc.translatePath( __addon__.getAddonInfo('profile') )
+__temp__       = xbmc.translatePath( os.path.join( __profile__, 'temp', '') )
 
 if xbmcvfs.exists(__temp__):
   shutil.rmtree(__temp__)


### PR DESCRIPTION
Running on Kodi-devel:

```sh-session
romain@marvin ~ % kodi --version
19.0-ALPHA1 (18.9.701) Git:19.0a1-Matri Media Center Kodi
Copyright (C) 2005-2018 Team Kodi - http://kodi.tv
```

an exception is raised when searching for subtitles:

```
2020-12-29 06:18:53.128 T:101637    INFO <general>: initializing python engine.
2020-12-29 06:18:53.158 T:101637   ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'AttributeError'>
                                                   Error Contents: module 'xbmcvfs' has no attribute 'translatePath'
                                                   Traceback (most recent call last):
                                                     File "/home/romain/.kodi/addons/service.subtitles.opensubtitles/service.py", line 20, in <module>
                                                       __cwd__        = xbmcvfs.translatePath( __addon__.getAddonInfo('path') )
                                                   AttributeError: module 'xbmcvfs' has no attribute 'translatePath'
                                                   -->End of Python script error report<--

2020-12-29 06:18:53.192 T:101637 WARNING <general>: CPythonInvoker(4, /home/romain/.kodi/addons/service.subtitles.opensubtitles/service.py): the python script "/home/romain/.kodi/addons/service.subtitles.opensubtitles/service.py" has left several classes in memory that we couldn't clean up. The classes include: N9XBMCAddon9xbmcaddon5AddonE
2020-12-29 06:18:53.192 T:101637    INFO <general>: Python interpreter stopped
2020-12-29 06:18:53.213 T:101384   ERROR <general>: GetDirectory - Error getting plugin://service.subtitles.opensubtitles/?action=search&languages=English%2cFrench&preferredlanguage=Undetermined
```

This fix this issue by calling translatePath() on `xbmc`, not `xbmcvfs`.